### PR TITLE
AD-HOC feat (ssmtp): Add SSMTP to stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ sufficiently granular for you to track your project against, I recommend you fin
 
 ## Usage
 
+### Mail
+
+Part of many PHP applications is the need to send mail. This project includes the mail transfer agent "ssmtp". This
+agent is an extremely simple sendmail compatible agent, designed to forward mail directly to an MTA that's running
+colocated with this container such as Postfix or Mailhog.
+
+It is configured to look for MTAs at the domain `mail`. This means that the DNS should return a match for the service
+`mail`, perhaps through the use of a record directly or through the use of search domains. This is accomplished by:
+
+- **docker-compose**: Calling the service "mail"
+- **kubernetes**: Creating a service called "mail"
+
+In both cases mail should arrive appropriately.
+
 ### TLS
 
 Please **DO NOT** use the self signed certificate that is packaged in the container for anything other than testing. It

--- a/fs/opt/provision/provision.sh
+++ b/fs/opt/provision/provision.sh
@@ -7,6 +7,8 @@
 #  ENV TINI_VERSION "16.1" # Optional
 #
 
+set -e
+
 TINI_VERSION=${TINI_VERSION:-v0.17.0}
 
 # Exit codes from sysexists.h
@@ -26,6 +28,17 @@ __check_env() {
   if [[ -z "$PHP_VERSION" ]] || [[ -z "$TINI_VERSION" ]]; then
       __exit "Expected environment variables PHP_VERSION and TINI_VERSION. Not found" $__EXIT_CODE_USAGE
   fi
+}
+
+__provision_mta() {
+    apt-get update && \
+        apt-get install --yes
+
+    # Configure the simple MTA to forward to the `mail` host
+    RUN sed --in-place 's/mailhub=mail/mailhub=mail:25/' /etc/ssmtp/ssmtp.conf && \
+        echo "FromLineOverride=YES" >> /etc/ssmtp/ssmtp.conf
+
+    return $?
 }
 
 __provision() {
@@ -116,6 +129,8 @@ __provision() {
     # Build cleanup
     #
     apt-get purge --yes ${CONTAINER_BUILD_PACKAGES}
+
+    return $?
 }
 
 main() {


### PR DESCRIPTION
An extremely common problem that must be solved in PHP is the
requirement to send mail. This commit adds the mta SSMTP to the
application, which will forward mail immediately in the invocation of
the sendmail binary. It thus works as an effective shim between the
single process of Apache and "real" MTAs